### PR TITLE
Make complexityplots directly usable by new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install the Python library requirements, run:
 
 To initialise the database (SQLite is used by default), run:
     
-    run python manage.py syncdb
+    python manage.py syncdb
 
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ To install the Python library requirements, run:
 
     pip install -r requirements.txt
 
+To initialise the database (SQLite is used by default), run:
+    
+    run python manage.py syncdb
+
+
 ## Running
 
 Though the client and server can be run independently (and they are in fact run as such our ovii server), you can run them both on your local machine simply with:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ To install the Python library requirements, run:
 
     pip install -r requirements.txt
 
+or, if you want to use Postgres as the dabase backend:
+
+    pip install -r requirements-postgres.txt
+
 To initialise the database (SQLite is used by default), run:
     
     python manage.py syncdb

--- a/complexityplot/complexityplot/settings.py
+++ b/complexityplot/complexityplot/settings.py
@@ -5,6 +5,8 @@ import os
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) 
+
 ADMINS = (
     ('Simon Walton', 'simon.walton@oerc.ox.ac.uk'),
 )
@@ -63,9 +65,9 @@ MEDIA_URL = ''
 # Don't put anything in this directory yourself; store your static files
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
 # Example: "/var/www/example.com/static/"
-STATIC_ROOT = "/Users/sim/Documents/ComplexityPlot/Web/complexityplot/"
+STATIC_ROOT = BASE_DIR
 
-BASE_DIR = "/Users/sim/Documents/ComplexityPlot/Web/complexityplot/"
+BASE_DIR = BASE_DIR
 
 # URL prefix for static files.
 # Example: "http://example.com/static/", "http://static.example.com/"
@@ -123,7 +125,7 @@ TEMPLATE_DIRS = (
     # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
-    "/Users/sim/Documents/ComplexityPlot/Web/complexityplot/templates/"
+    os.path.normpath(os.path.join(BASE_DIR, 'templates'))
 )
 
 INSTALLED_APPS = (

--- a/requirements-postgres.txt
+++ b/requirements-postgres.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+psycopg2==2.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,10 @@
 Django==1.5.1
 South==0.7.6
-distribute==0.6.35
 dj-database-url==0.2.1
 gunicorn==0.17.2
 heroku==0.1.2
 ipython==0.13.1
 numpy==1.7.0
-psycopg2==2.4.6
 python-dateutil==1.5
 requests==1.2.0
 virtualenv==1.9.1


### PR DESCRIPTION
- Explain how to initialise the database
- Automatically generate paths relative to location of ``settings.py``, avoiding the need for users to edit hard-coded absolute paths